### PR TITLE
Remove check in favour of default flag value

### DIFF
--- a/main.go
+++ b/main.go
@@ -122,7 +122,7 @@ func syncCmd() *cobra.Command {
 
 func addFlags(cmd *cobra.Command, file *string, terraformVersion *string) {
 	cmd.Flags().StringVarP(file, "config.file", "f", "./config.yaml", "OpenPaaS configuration file to use")
-	cmd.Flags().StringVarP(terraformVersion, "terraform.version", "t", "1.7.2", "Terraform version to use")
+	cmd.Flags().StringVarP(terraformVersion, "terraform.version", "t", "1.7.3", "Terraform version to use")
 }
 
 func initStack(ctx context.Context, file string, terraformVersion string) (*conf.Config, *ansible.Inventory, error) {

--- a/pkg/terraform/init_terraform.go
+++ b/pkg/terraform/init_terraform.go
@@ -17,11 +17,6 @@ func InitTf(ctx context.Context, workingDir string, terraformVersion string, std
 
 	i := install.NewInstaller()
 
-	// Set terraformVersion version if not provided
-	if terraformVersion == "" {
-		terraformVersion = "1.7.3"
-	}
-
 	selectedVersion := version.Must(version.NewVersion(terraformVersion))
 
 	execPath, err := i.Ensure(ctx, []src.Source{


### PR DESCRIPTION
The terraform flag sets a default value if not provided, so we don't need to make this check any more

This also makes it easier to keep the default version updated