### PR TITLE
Adds default playbooks and default hardening for Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ Ties together Terraform, Ansible and Runtime execution of commands (local) to cr
 - [ ] enable remote backend for TF for coordination, based on some flag
 - [ ] using systemctl, setup nginx, upload/download binary, upload service, restart service
 - [ ] hetzner minimum viable config (2 boxes, 1 load balancer, 1 postgres, private network)
-- [ ] set up postgres and backups? single ndoe with continues backup + daily snapshot?
+- [ ] set up postgres and backups? single node with continues backup + daily snapshot?
 - [ ] postgres to master/slave
 - [ ] o11y at infra level (grafana, tempo, loki, successor-to-prometheus) as a playbook

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -7,6 +7,7 @@ server_groups:
     num: 3
     lb_target: false
     instance_type: cx21
+    os_image: ubuntu-22.04
  #   volumes: 
  #   - name: "data_vol"
  #     path: /opt/nomad_server_data
@@ -16,6 +17,7 @@ server_groups:
     num: 2
     lb_target: true # should probably be is_lb_target instead, more natural
     instance_type: cx21
+    os_image: ubuntu-22.04
 
 providers:
   ansible:

--- a/pkg/ansible/conf.go
+++ b/pkg/ansible/conf.go
@@ -42,6 +42,7 @@ type Host struct {
 	HostName  string `json:"host_name"`
 	PrivateIP string `json:"private_ip"`
 	ServerID  string `json:"server_id"`
+	Image     string `json:"image"`
 }
 
 type All struct {
@@ -193,6 +194,7 @@ func GenerateInventory(config *conf.Config) (*Inventory, error) {
 			ID:        v.ServerID,
 			ExtraVars: map[string]string{
 				"datacenter": config.DC,
+				"os":         v.Image,
 			},
 		}
 

--- a/pkg/ansible/conf_test.go
+++ b/pkg/ansible/conf_test.go
@@ -63,5 +63,6 @@ func TestGenerateInventory(t *testing.T) {
 	assert.Equal(t, "venue-servers-1", host.HostName)
 	assert.Equal(t, "10.0.1.2", host.PrivateIP)
 	assert.Equal(t, "138.201.186.150", host.PublicIP)
+	assert.Equal(t, map[string]string{"datacenter": "hetzner", "os": "ubuntu-22.04"}, host.ExtraVars)
 
 }

--- a/pkg/ansible/testdata/inventory-output.json
+++ b/pkg/ansible/testdata/inventory-output.json
@@ -21,7 +21,8 @@
             "host": "string",
             "host_name": "string",
             "private_ip": "string",
-            "server_id": "string"
+            "server_id": "string",
+            "image": "string"
           }
         ],
         [
@@ -31,7 +32,8 @@
             "host": "string",
             "host_name": "string",
             "private_ip": "string",
-            "server_id": "string"
+            "server_id": "string",
+            "image": "string"
           }
         ],
         [
@@ -41,7 +43,8 @@
             "host": "string",
             "host_name": "string",
             "private_ip": "string",
-            "server_id": "string"
+            "server_id": "string",
+            "image": "string"
           }
         ],
         [
@@ -51,7 +54,8 @@
             "host": "string",
             "host_name": "string",
             "private_ip": "string",
-            "server_id": "string"
+            "server_id": "string",
+            "image": "string"
           }
         ]
       ]
@@ -62,35 +66,40 @@
         "host": "167.235.226.255",
         "host_name": "venue-clients-1",
         "private_ip": "10.0.0.2",
-        "server_id": "30421328"
+        "server_id": "30421328",
+        "image": "ubuntu-22.04"
       },
       {
         "group": "clients",
         "host": "138.201.175.94",
         "host_name": "venue-clients-2",
         "private_ip": "10.0.0.3",
-        "server_id": "30421329"
+        "server_id": "30421329",
+        "image": "ubuntu-22.04"
       },
       {
         "group": "servers",
         "host": "138.201.186.150",
         "host_name": "venue-servers-1",
         "private_ip": "10.0.1.2",
-        "server_id": "30421332"
+        "server_id": "30421332",
+        "image": "ubuntu-22.04"
       },
       {
         "group": "servers",
         "host": "23.88.33.71",
         "host_name": "venue-servers-2",
         "private_ip": "10.0.1.3",
-        "server_id": "30421327"
+        "server_id": "30421327",
+        "image": "ubuntu-22.04"
       },
       {
         "group": "servers",
         "host": "91.107.199.4",
         "host_name": "venue-servers-3",
         "private_ip": "10.0.1.4",
-        "server_id": "30421330"
+        "server_id": "30421330",
+        "image": "ubuntu-22.04"
       }
     ]
   },

--- a/pkg/conf/config.go
+++ b/pkg/conf/config.go
@@ -25,6 +25,7 @@ type ServerGroup struct {
 	Volumes      []Volume `yaml:"volumes"`
 	LbTarget     bool     `yaml:"lb_target"`
 	Aliases      []string `yaml:"aliases"`
+	Image        string   `yaml:"os_image"`
 }
 
 type Volume struct {

--- a/pkg/provider/ansible_provider.go
+++ b/pkg/provider/ansible_provider.go
@@ -31,8 +31,11 @@ type Playbook struct {
 //go:embed defaults/hardening-ubuntu-2204.yml
 var hardeningUbuntu string
 
+//go:embed defaults/mount-volumes.yml
+var upgradeAndMountUbuntu string
+
 // add them in the order they need to be applied
-var defaultPlaybooks []string = []string{hardeningUbuntu}
+var defaultPlaybooks []string = []string{hardeningUbuntu, upgradeAndMountUbuntu}
 
 func (s *Ansible) Run(ctx context.Context, providerConfig interface{}, inventory *ansible.Inventory) error {
 	conf, err := asAnsibleConfig(providerConfig)

--- a/pkg/provider/defaults/hardening-ubuntu-2204.yml
+++ b/pkg/provider/defaults/hardening-ubuntu-2204.yml
@@ -7,6 +7,11 @@
   tasks:
     - name: Apply hardening if OS is Ubuntu 22.04
       block:
+        - name: Update all packages to the latest version
+          apt:
+            update_cache: yes
+            upgrade: dist
+            cache_valid_time: 3600 # Optional: cache valid time in seconds
         - name: Update and upgrade all packages to the latest version
           ansible.builtin.apt:
             upgrade: dist

--- a/pkg/provider/defaults/hardening-ubuntu-2204.yml
+++ b/pkg/provider/defaults/hardening-ubuntu-2204.yml
@@ -1,0 +1,115 @@
+---
+- name: Ubuntu 22.04 Hardening
+  hosts: all
+  become: true
+  gather_facts: yes
+
+  tasks:
+    - name: Apply hardening if OS is Ubuntu 22.04
+      block:
+        - name: Update and upgrade all packages to the latest version
+          ansible.builtin.apt:
+            upgrade: dist
+            update_cache: yes
+            cache_valid_time: 3600
+
+        # UFW
+        - name: Ensure UFW is installed
+          ansible.builtin.apt:
+            name: ufw
+            state: present
+        - name: Enable UFW
+          ansible.builtin.ufw:
+            state: enabled
+            policy: deny
+            direction: incoming
+        - name: Allow SSH in UFW
+          ansible.builtin.ufw:
+            rule: allow
+            name: OpenSSH
+
+        # SSH
+        - name: Secure SSH Configuration
+          ansible.builtin.lineinfile:
+            path: /etc/ssh/sshd_config
+            regexp: "{{ item.regexp }}"
+            line: "{{ item.line }}"
+          with_items:
+            # - { regexp: "^#?Port", line: "Port 2222" }
+            # - { regexp: "^#?PermitRootLogin", line: "PermitRootLogin no" }
+            - { regexp: "^#?PasswordAuthentication", line: "PasswordAuthentication no" }
+            - { regexp: "^#?X11Forwarding", line: "X11Forwarding no" }
+            - { regexp: "^#?MaxAuthTries", line: "MaxAuthTries 6" }
+            - { regexp: "^#?ClientAliveInterval", line: "ClientAliveInterval 300" }
+            - { regexp: "^#?ClientAliveCountMax", line: "ClientAliveCountMax 3" }
+            - { regexp: "^#?AllowTcpForwarding", line: "AllowTcpForwarding no" }
+            - { regexp: "^#?AllowAgentForwarding", line: "AllowAgentForwarding no" }
+            - { regexp: "^#?AuthorizedKeysFile", line: "AuthorizedKeysFile .ssh/authorized_keys" }
+          notify: restart ssh
+        #Fail2Ban
+        - name: Install fail2ban
+          ansible.builtin.apt:
+            name: fail2ban
+            state: present
+
+        - name: Ensure fail2ban is running and enabled
+          ansible.builtin.service:
+            name: fail2ban
+            state: started
+            enabled: yes
+
+        - name: Deploy custom fail2ban jail configuration
+          ansible.builtin.copy:
+            dest: /etc/fail2ban/jail.local
+            content: |
+              [DEFAULT]
+              bantime = 1h
+              findtime = 10m
+              maxretry = 6
+              backend = auto
+              banaction = ufw
+              
+              [sshd]
+              enabled = true
+              port    = ssh
+              filter  = sshd
+              logpath = /var/log/auth.log
+            owner: root
+            group: root
+            mode: '0644'
+          notify: restart fail2ban
+
+        # Security updates using the default configuration
+        # Relevant files:
+        # - /etc/apt/apt.conf.d/50unattended-upgrades
+        # - /etc/apt/apt.conf.d/20auto-upgrades
+        - name: Install unattended-upgrades package
+          ansible.builtin.apt:
+            name: unattended-upgrades
+            state: present
+
+        # Other
+        - name: Remove unnecessary packages
+          ansible.builtin.apt:
+            name: "{{ item }}"
+            state: absent
+          loop:
+            - telnet
+            - nis
+            - rsh-client
+            - rsh-redone-client
+
+      # condition for the block
+      when: hostvars[inventory_hostname]['extra_vars']['os'] == 'ubuntu-22.04'
+
+
+  handlers:
+    - name: restart ssh
+      ansible.builtin.service:
+        name: ssh
+        state: restarted
+
+    - name: restart fail2ban
+      ansible.builtin.service:
+        name: fail2ban
+        state: restarted

--- a/pkg/provider/defaults/mount-volumes.yml
+++ b/pkg/provider/defaults/mount-volumes.yml
@@ -1,0 +1,43 @@
+---
+- name: Mount volumes
+  hosts: all
+  become: true
+  tasks:
+    - name: Ensure group exists
+      group:
+        name: "{{ item.owner }}"
+        state: present
+      loop: "{{ hostvars[inventory_hostname].mounts | default([]) }}"
+      when: hostvars[inventory_hostname].mounts is defined
+      become: yes
+      loop_control:
+        label: "{{ item.owner }}"
+    - name: Ensure user and group exist
+      user:
+        name: "{{ item.owner }}"
+        group: "{{ item.owner }}"
+        state: present
+        createhome: yes 
+      loop: "{{ hostvars[inventory_hostname].mounts | default([]) }}"
+      when: hostvars[inventory_hostname].mounts is defined
+      become: yes
+    - name: Ensure mount points exist and have correct ownership
+      file:
+        path: "{{ item.path }}"
+        state: directory
+        owner: "{{ item.owner }}"
+        group: "{{ item.owner }}"
+      with_items: "{{ hostvars[inventory_hostname].mounts }}"
+      when: hostvars[inventory_hostname].mounts is defined
+      become: yes
+
+    - name: Mount filesystems
+      mount:
+        path: "{{ item.path }}"
+        src: "{{ item.mount_path }}"
+        fstype: none  # For bind mounts, fstype is 'none'
+        opts: bind  # Specify 'bind' to indicate a bind mount
+        state: mounted
+      with_items: "{{ hostvars[inventory_hostname].mounts }}"
+      when: hostvars[inventory_hostname].mounts is defined
+      become: yes

--- a/pkg/terraform/templates/hetzner/main.tf
+++ b/pkg/terraform/templates/hetzner/main.tf
@@ -128,7 +128,7 @@ resource "hcloud_firewall_attachment" "fw_ref" {
 resource "hcloud_server" "server_node" {
   for_each           = { for entry in local.servers : "${entry.name}" => entry }
   name               = each.value.name
-  image              = "ubuntu-22.04"
+  image              = each.value.image
   server_type        = each.value.server_type
   location           = var.location
   placement_group_id = hcloud_placement_group.placement_group[each.value.group].id
@@ -142,7 +142,8 @@ resource "hcloud_server" "server_node" {
   ]
 
   labels = {
-    "group" = each.value.group_name
+    "group" = each.value.group_name,
+    "os" = each.value.image
   }
 
   ssh_keys = [for id in var.ssh_keys : id]
@@ -249,6 +250,7 @@ output "servers" {
         private_ip = "${server.private_ip}",
         server_id  = node.id
         group      = node.labels["group"]
+        image      = "${node.image}"
       } if server.name == node.name
     ]
   ])

--- a/pkg/terraform/templates/hetzner/main.tf
+++ b/pkg/terraform/templates/hetzner/main.tf
@@ -18,6 +18,7 @@ locals {
     value.name => {
       count  = value.num,
       subnet = "${i}", group = i, server_type = value.instance_type, lb_target = value.lb_target,
+      image = value.image,
       volumes = value.volumes
     }
   }
@@ -33,6 +34,7 @@ locals {
         lb_target   = value.lb_target
         server_type = value.server_type
         volumes     = value.volumes
+        image       = value.image
       }
     ]
   ])

--- a/pkg/terraform/templates/hetzner/vars.tf
+++ b/pkg/terraform/templates/hetzner/vars.tf
@@ -11,6 +11,7 @@ variable "server_groups" {
     instance_type = "{{ $value.InstanceType}}"
     num = {{ $value.Num }}
     lb_target = {{ $value.LbTarget}}
+    image = "{{ $value.Image }}"
     volumes = [{{ range $key, $value := $value.Volumes}}
      {
       name = "{{ $value.Name }}"

--- a/pkg/testdata/config.yaml
+++ b/pkg/testdata/config.yaml
@@ -7,6 +7,7 @@ server_groups:
   servers:
     num: 3
     instance_type: cx21
+    os_image: ubuntu-22.04
     volumes: 
     - name: "data_vol"
       path: /opt/nomad_server_data
@@ -17,6 +18,7 @@ server_groups:
   clients:
     num: 2
     instance_type: cpx31
+    os_image: ubuntu-22.04
 providers:
   ansible:
     sudo_user: root

--- a/pkg/testdata/inventory.json
+++ b/pkg/testdata/inventory.json
@@ -11,7 +11,8 @@
             "host": "string",
             "host_name": "string",
             "private_ip": "string",
-            "server_id": "string"
+            "server_id": "string",
+            "image": "string"
           }
         ],
         [
@@ -21,7 +22,8 @@
             "host": "string",
             "host_name": "string",
             "private_ip": "string",
-            "server_id": "string"
+            "server_id": "string",
+            "image": "string"
           }
         ],
         [
@@ -31,7 +33,8 @@
             "host": "string",
             "host_name": "string",
             "private_ip": "string",
-            "server_id": "string"
+            "server_id": "string",
+            "image": "string"
           }
         ],
         [
@@ -41,7 +44,8 @@
             "host": "string",
             "host_name": "string",
             "private_ip": "string",
-            "server_id": "string"
+            "server_id": "string",
+            "image": "string"
           }
         ],
         [
@@ -51,7 +55,8 @@
             "host": "string",
             "host_name": "string",
             "private_ip": "string",
-            "server_id": "string"
+            "server_id": "string",
+            "image": "string"
           }
         ]
       ]
@@ -62,35 +67,40 @@
         "host": "167.235.226.255",
         "host_name": "venue-clients-1",
         "private_ip": "10.0.0.2",
-        "server_id": "30421328"
+        "server_id": "30421328",
+        "image": "ubuntu-22.04"
       },
       {
         "group": "clients",
         "host": "138.201.175.94",
         "host_name": "venue-clients-2",
         "private_ip": "10.0.0.3",
-        "server_id": "30421329"
+        "server_id": "30421329",
+        "image": "ubuntu-22.04"
       },
       {
         "group": "servers",
         "host": "138.201.186.150",
         "host_name": "venue-servers-1",
         "private_ip": "10.0.1.2",
-        "server_id": "30421332"
+        "server_id": "30421332",
+        "image": "ubuntu-22.04"
       },
       {
         "group": "servers",
         "host": "23.88.33.71",
         "host_name": "venue-servers-2",
         "private_ip": "10.0.1.3",
-        "server_id": "30421327"
+        "server_id": "30421327",
+        "image": "ubuntu-22.04"
       },
       {
         "group": "servers",
         "host": "91.107.199.4",
         "host_name": "venue-servers-3",
         "private_ip": "10.0.1.4",
-        "server_id": "30421330"
+        "server_id": "30421330",
+        "image": "ubuntu-22.04"
       }
     ]
   },


### PR DESCRIPTION
- Make the OS image configurable for the servers. Servers will have an extra label in Hetzner and the inventory file, showing the OS.
- Adds the possibility to run default playbooks on the servers. They run before any client playbook. It can be used for tasks like hardening the OS. The playbooks can take advantage of the new `image` label in the inventory to make sure they run only on systems that support the operations 
- Adds a default playbook to harden installations of Ubuntu 22.04

Questions:

- Currently we can't disable root login in sshd, as Ansible will be using that user, and as that user is getting the ssh keys when we create the server. We could replace that user by the user in the config, probably by running first some book that prepares the ssh keys for the new user, and then running the other playbooks as the new user. Do we want this?

- Similar issue with the ssh port, do we want to change the default 22 to another? It is a recommended security practice, but has implications regarding how we run the playbooks.
