### PR TITLE
Pv/terraform s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,7 @@ Ties together Terraform, Ansible and Runtime execution of commands (local) to cr
 ## TODO
 
 - [ ] add documentation to parts of the code (I need to work more with it)
-- [ ] enable remote backend for TF for coordination, based on some flag
 - [ ] using systemctl, setup nginx, upload/download binary, upload service, restart service
 - [ ] hetzner minimum viable config (2 boxes, 1 load balancer, 1 postgres, private network)
-- [ ] set up postgres and backups? single node with continues backup + daily snapshot?
 - [ ] postgres to master/slave
 - [ ] o11y at infra level (grafana, tempo, loki, successor-to-prometheus) as a playbook

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -8,8 +8,8 @@ terraform_state:
     endpoint: endpoint_to_s3_compatible_storage
     bucket: bucket_name
     region: auto
-    access_key: your_access_key
-    secret_key: your_secret_key
+    access_key: hardcoded_or_env_var
+    secret_key: ENV_SECRET_ACCESS_KEY
 
 server_groups:
   server:

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -2,6 +2,15 @@ dc_name: hetzner
 base_dir: config
 org_name: chaordic
 
+terraform_state:
+  backend: s3 # s3 or local
+  config:
+    endpoint: endpoint_to_s3_compatible_storage
+    bucket: bucket_name
+    region: auto
+    access_key: your_access_key
+    secret_key: your_secret_key
+
 server_groups:
   server:
     num: 3

--- a/pkg/conf/config.go
+++ b/pkg/conf/config.go
@@ -13,10 +13,16 @@ type Config struct {
 	DC                  string                 `yaml:"dc_name"`
 	BaseDir             string                 `yaml:"base_dir"`
 	OrgName             string                 `yaml:"org_name"`
+	TfState             TerraformState         `yaml:"terraform_state"`
 	Providers           map[string]interface{} `yaml:"providers"`
 	CloudProviderConfig CloudProvider          `yaml:"cloud_provider_config"`
 	ServerGroups        map[string]ServerGroup `yaml:"server_groups"`
 	Services            map[string]interface{} `yaml:"services"`
+}
+
+type TerraformState struct {
+	Backend string            `yaml:"backend"`
+	Config  map[string]string `yaml:"config"`
 }
 
 type ServerGroup struct {

--- a/pkg/conf/config.go
+++ b/pkg/conf/config.go
@@ -83,10 +83,25 @@ func Load(file string) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// replace any env vars in the Tf State config with their values
+	config.TfState = updateTerraformStateVarsConfig(config.TfState)
+
 	return &config, nil
 }
 
 func LoadTFExecVars() *tfexec.VarOption {
 	token := os.Getenv("HETZNER_TOKEN")
 	return tfexec.Var(fmt.Sprintf("hcloud_token=%s", token))
+}
+
+func updateTerraformStateVarsConfig(tfState TerraformState) TerraformState {
+	for key, value := range tfState.Config {
+		envValue, exists := os.LookupEnv(value)
+		// If the environment variable exists and is not an empty string, replace the value for that key in the map
+		if exists && envValue != "" {
+			tfState.Config[key] = envValue
+		}
+	}
+	return tfState
 }

--- a/pkg/conf/config_test.go
+++ b/pkg/conf/config_test.go
@@ -20,6 +20,15 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, "hetzner", conf.CloudProviderConfig.Provider)
 	assert.Equal(t, []string{"wfaler"}, conf.CloudProviderConfig.GithubIds)
 
+	assert.Equal(t, "s3", conf.TfState.Backend)
+	expected := map[string]string{"endpoint": "endpoint_to_s3_compatible_storage",
+		"bucket":     "bucket_name",
+		"region":     "auto",
+		"access_key": "your_access_key",
+		"secret_key": "your_secret_key",
+	}
+	assert.Equal(t, expected, conf.TfState.Config)
+
 	assert.Len(t, conf.ServerGroups, 2)
 	assert.Equal(t, "cpx31", conf.ServerGroups["clients"].InstanceType)
 	assert.Equal(t, 2, conf.ServerGroups["clients"].Num)

--- a/pkg/conf/config_test.go
+++ b/pkg/conf/config_test.go
@@ -2,6 +2,7 @@ package conf
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -19,13 +20,50 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, "hetzner", conf.DC)
 	assert.Equal(t, "hetzner", conf.CloudProviderConfig.Provider)
 	assert.Equal(t, []string{"wfaler"}, conf.CloudProviderConfig.GithubIds)
-
 	assert.Equal(t, "s3", conf.TfState.Backend)
+
+	// we don't have env vars set, so access and secret keys show the string provided
 	expected := map[string]string{"endpoint": "endpoint_to_s3_compatible_storage",
 		"bucket":     "bucket_name",
 		"region":     "auto",
-		"access_key": "your_access_key",
-		"secret_key": "your_secret_key",
+		"access_key": "env_var_access_key",
+		"secret_key": "env_var_secret_key",
+	}
+	assert.Equal(t, expected, conf.TfState.Config)
+
+	assert.Len(t, conf.ServerGroups, 2)
+	assert.Equal(t, "cpx31", conf.ServerGroups["clients"].InstanceType)
+	assert.Equal(t, 2, conf.ServerGroups["clients"].Num)
+	assert.Equal(t, 20, conf.ServerGroups["servers"].Volumes[0].Size)
+	assert.Equal(t, "data_vol", conf.ServerGroups["servers"].Volumes[0].Name)
+	assert.Equal(t, "/opt/nomad_server_data", conf.ServerGroups["servers"].Volumes[0].Path)
+	assert.Equal(t, []string{"consul"}, conf.ServerGroups["servers"].Aliases)
+
+}
+
+func TestLoadConfigWithEnvVars(t *testing.T) {
+	err := os.Setenv("env_var_access_key", "access_key")
+	require.NoError(t, err)
+	err = os.Setenv("env_var_secret_key", "secret_key")
+	require.NoError(t, err)
+
+	conf, err := Load(filepath.Join("..", "testdata", "config.yaml"))
+	require.NoError(t, err)
+	assert.NotNil(t, conf)
+	fmt.Println(conf)
+
+	assert.Equal(t, "config", conf.BaseDir)
+	assert.Equal(t, "hetzner", conf.DC)
+	assert.Equal(t, "hetzner", conf.CloudProviderConfig.Provider)
+	assert.Equal(t, []string{"wfaler"}, conf.CloudProviderConfig.GithubIds)
+	assert.Equal(t, "s3", conf.TfState.Backend)
+
+	// we have env vars set, so access and secret keys are replaced accordingly
+	expected := map[string]string{"endpoint": "endpoint_to_s3_compatible_storage",
+		"bucket":     "bucket_name",
+		"region":     "auto",
+		"access_key": "access_key",
+		"secret_key": "secret_key",
 	}
 	assert.Equal(t, expected, conf.TfState.Config)
 

--- a/pkg/provider/defaults/hardening-ubuntu-2204.yml
+++ b/pkg/provider/defaults/hardening-ubuntu-2204.yml
@@ -12,11 +12,6 @@
             update_cache: yes
             upgrade: dist
             cache_valid_time: 3600 # Optional: cache valid time in seconds
-        - name: Update and upgrade all packages to the latest version
-          ansible.builtin.apt:
-            upgrade: dist
-            update_cache: yes
-            cache_valid_time: 3600
 
         # UFW
         - name: Ensure UFW is installed

--- a/pkg/terraform/templates/hetzner/main.tf
+++ b/pkg/terraform/templates/hetzner/main.tf
@@ -5,7 +5,24 @@ terraform {
       version = "1.44.1"
     }
   }
+  {{if eq .TfState.Backend "s3"}}
+  backend "s3" {
+    endpoints                   = { s3 = "{{.TfState.Config.endpoint }}" }
+    bucket                      = "{{.TfState.Config.bucket }}"
+    key                         = "openpaas/terraform.tfstate"
+    region                      = "{{.TfState.Config.region }}"
+    access_key                  = "{{.TfState.Config.access_key }}"
+    secret_key                  = "{{.TfState.Config.secret_key }}"
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_s3_checksum = true
+    force_path_style            = true
 }
+  {{ end }}
+}
+
 # Configure the Hetzner Cloud Provider
 provider "hcloud" {
   token = var.hcloud_token

--- a/pkg/terraform/terraform.go
+++ b/pkg/terraform/terraform.go
@@ -33,13 +33,22 @@ func GenerateTerraform(config *conf.Config) error {
 		return fmt.Errorf("%s is not a supported cloud provider", config.CloudProviderConfig.Provider)
 	}
 
+	tmplMain, e := template.New("tf-main").Parse(tfSettings.Main)
+	if e != nil {
+		return e
+	}
+	var bufMain bytes.Buffer
+	err := tmplMain.Execute(&bufMain, config)
+	if err != nil {
+		return err
+	}
+
 	tmplVars, e := template.New("tf-vars").Parse(tfSettings.Vars)
 	if e != nil {
 		return e
 	}
 	var bufVars bytes.Buffer
-
-	err := tmplVars.Execute(&bufVars, config)
+	err = tmplVars.Execute(&bufVars, config)
 	if err != nil {
 		return err
 	}
@@ -54,7 +63,7 @@ func GenerateTerraform(config *conf.Config) error {
 	if err != nil {
 		return err
 	}
-	err = os.WriteFile(filepath.Clean(filepath.Join(folder, "main.tf")), []byte(hetznerMain), 0600)
+	err = os.WriteFile(filepath.Clean(filepath.Join(folder, "main.tf")), bufMain.Bytes(), 0600)
 	if err != nil {
 		return err
 	}

--- a/pkg/terraform/terraform_test.go
+++ b/pkg/terraform/terraform_test.go
@@ -178,8 +178,8 @@ func TestGenerateTerraformWithS3(t *testing.T) {
 		"endpoint":   cty.StringVal("endpoint_to_s3_compatible_storage"),
 		"bucket":     cty.StringVal("bucket_name"),
 		"region":     cty.StringVal("auto"),
-		"access_key": cty.StringVal("your_access_key"),
-		"secret_key": cty.StringVal("your_secret_key"),
+		"access_key": cty.StringVal("env_var_access_key"),
+		"secret_key": cty.StringVal("env_var_secret_key"),
 		"key":        cty.StringVal("openpaas/terraform.tfstate"),
 	}
 

--- a/pkg/testdata/config.yaml
+++ b/pkg/testdata/config.yaml
@@ -3,6 +3,15 @@ inventory: datacenters/hetzner/inventory
 base_dir: config
 org_name: chaordic
 
+terraform_state:
+  backend: s3
+  config:
+    endpoint: endpoint_to_s3_compatible_storage
+    bucket: bucket_name
+    region: auto
+    access_key: your_access_key
+    secret_key: your_secret_key
+
 server_groups:
   servers:
     num: 3

--- a/pkg/testdata/config.yaml
+++ b/pkg/testdata/config.yaml
@@ -9,8 +9,8 @@ terraform_state:
     endpoint: endpoint_to_s3_compatible_storage
     bucket: bucket_name
     region: auto
-    access_key: your_access_key
-    secret_key: your_secret_key
+    access_key: env_var_access_key
+    secret_key: env_var_secret_key
 
 server_groups:
   servers:


### PR DESCRIPTION
Adds a s3-compatible backend (optional) to terraform.

If `terraform_state > backend` is set to `s3` in `config.yml`, the configuration will be stored in the S3-compatible backend (tested with R2)

If the value of the configuration is `local` (or, currently, something else than `s3`), it will use local storage.